### PR TITLE
Formatting Bug

### DIFF
--- a/swarm_translate/translate_ollama.py
+++ b/swarm_translate/translate_ollama.py
@@ -57,6 +57,7 @@ class TranslationScenario:
         filename = template.format(
             source_code=self.source_code,
             target_code=self.target_code,
+            date=date
         )
         if self.book is not None:
             filename += "-" + self.book

--- a/swarm_translate/translate_ollama.py
+++ b/swarm_translate/translate_ollama.py
@@ -54,6 +54,7 @@ class TranslationScenario:
     
     def get_output_path(self) -> Path:
         template = self.config["output"]["filename_template"]
+        date = datetime.now().strftime("%Y%m%d")
         filename = template.format(
             source_code=self.source_code,
             target_code=self.target_code,


### PR DESCRIPTION
Sorry, I had changed the formatting a bit when running it locally. Specifically, I had removed the "date" field in the output file name, but it throws an error if the scenario includes the date. This commit brings back the "date" field, so it runs with the scenarios as they are formatted in this repository.